### PR TITLE
Add 'Referer' field.. appears to be missing for standard W3C log format

### DIFF
--- a/NxLog-IIS/iis-nxlog.cfg
+++ b/NxLog-IIS/iis-nxlog.cfg
@@ -6,6 +6,9 @@
 # Microsoft - IIS-W3C 8.5
 [DEFAULT]
 plugin_id=1502
+tzone=UTC
+# IIS logs in UTC time.. Set it here to be sure it comes across if you have localized the 
+# time settings in use for your OSSIM instance
 
 [config]
 type=detector

--- a/NxLog-IIS/iis-nxlog.cfg
+++ b/NxLog-IIS/iis-nxlog.cfg
@@ -48,7 +48,7 @@ shutdown=
 
 [AA - W3C]
 event_type=event
-regexp=(?P<date>\w{3}\s+\d{1,2}\s\d\d:\d\d:\d\d)\s+(?P<device>\S+)\s+(?P<process>\S+)\s(?P<logtime>\S+\s\S+)\s(?P<sip>\S+)\s(?P<csmethod>\S+)\s(?P<csuristem>\S+)\s(?P<csuriquery>\S+)\s(?P<sport>\S+)\s(?P<csusername>\S+)\s(?P<cip>\S+)\s(?P<useragent>\S+)\s(?P<scstatus>\S+)\s(?P<scsubstatus>\S+)\s(?P<scwin32status>\S+)\s(?P<timetaken>\S+)
+regexp=(?P<date>\w{3}\s+\d{1,2}\s\d\d:\d\d:\d\d)\s+(?P<device>\S+)\s+(?P<process>\S+)\s(?P<logtime>\S+\s\S+)\s(?P<sip>\S+)\s(?P<csmethod>\S+)\s(?P<csuristem>\S+)\s(?P<csuriquery>\S+)\s(?P<sport>\S+)\s(?P<csusername>\S+)\s(?P<cip>\S+)\s(?P<useragent>\S+)\s(?P<referer>\S+)\s(?P<scstatus>\S+)\s(?P<scsubstatus>\S+)\s(?P<scwin32status>\S+)\s(?P<timetaken>\S+)
 device={$sip}
 src_ip={$cip}
 dst_ip={$sip}

--- a/NxLog-IIS/nxlog.conf
+++ b/NxLog-IIS/nxlog.conf
@@ -14,18 +14,20 @@ Pidfile %ROOT%\data\nxlog.pid
 SpoolDir %ROOT%\data
 LogFile %ROOT%\data\nxlog.log
 
-#Where your logs are
-define IIS_LOGS C:\inetpub\logs\LogFiles\W3SVC1
-
 <Extension syslog>
     Module	xm_syslog
 </Extension>
+
+define IIS_LOGS C:\inetpub\logs\LogFiles
 
 
 #Define IIS Source
 <Input IIS>
 Module im_file
-File "%IIS_LOGS%\u*"
+File "%IIS_LOGS%\\\*"
+## Note the unusual three slash syntax - this allows recursive access to subfolders, porting all IIS logs. 
+## This can also use %IIS_LOGS%\W3SVC1\u* for the first IIS site, etc. 
+## See http://stackoverflow.com/questions/34401065/
 SavePos TRUE
 #Add in Syslog Fields
 Exec $SourceName = 'IIS';


### PR DESCRIPTION
The referrer field looks like it's missing in the regex. I'm testing against IIS 8.5 but it should be true across the board. 
